### PR TITLE
Disable GKE client cert auth

### DIFF
--- a/terraform/gcp/modules/icl-cluster/main.tf
+++ b/terraform/gcp/modules/icl-cluster/main.tf
@@ -10,6 +10,11 @@ resource "google_container_cluster" "cluster" {
   node_version = var.node_version
   min_master_version = var.node_version
   remove_default_node_pool = false
+  master_auth {
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
 }
 
 output "network" {


### PR DESCRIPTION
Set issue_client_certificate to "false" to disable legacy auth method thus decreasing the attack surface.

According to [Google's documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#authenticating_using_oauth), we use OAuth and can explicitly disable cert authentication.

Default value is assigned on the API side, as [value is computed](https://github.com/hashicorp/terraform-provider-google/blob/9fd2d1000ad9224cbc444e17708d3d8a09e5f69c/google/services/container/resource_container_cluster.go#L1181)(known after apply). Also, [authentication documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#legacy-auth) mentions that this is disabled since 1.12, but we're already on 1.28. May be not relevant for us.