### PR TITLE
Disable user scheduler for jupyterhub

### DIFF
--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -199,6 +199,9 @@ resource "helm_release" "jupyterhub" {
           - jupyter.${var.ingress_domain}
         annotations:
           nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      scheduling:
+        userScheduler:
+          enabled: false
     EOT
   ]
 }


### PR DESCRIPTION
This makes jupyterhub distribute sessions distribute evenly among nodes.