### PR TITLE
Disable chown/chgrp on start (set fsGroupChangePolicy to OnRootMismatch)

### DIFF
--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -9,7 +9,12 @@ locals {
       # enable cluster admin
       service_account = var.jupyterhub_cluster_admin_enabled ? kubernetes_service_account.admin.0.metadata.0.name : null
       automount_service_account_token = var.jupyterhub_cluster_admin_enabled
+      pod_security_context = {
+        fsGroup = 100
+        fsGroupChangePolicy = "OnRootMismatch"
+      }
     }
+
     default = true
   }
 

--- a/terraform/modules/jupyterhub/main.tf
+++ b/terraform/modules/jupyterhub/main.tf
@@ -14,7 +14,6 @@ locals {
         fsGroupChangePolicy = "OnRootMismatch"
       }
     }
-
     default = true
   }
 


### PR DESCRIPTION
For some users Jupyter session start time is very long due to lot of files in home directory. This PR disables this feature to allow faster start (sometimes less by minutes)