### PR TITLE
Update icl-jupyterhub image to 0.0.23 for Prefect 3.x

### DIFF
--- a/.github/workflows/docker-icl-jupyterhub.yaml
+++ b/.github/workflows/docker-icl-jupyterhub.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: Image tag
         required: true
-        default: 0.0.22
+        default: 0.0.23
       push:
         description: Push image to DockerHub
         required: true

--- a/docker/icl-jupyterhub-triton/Dockerfile
+++ b/docker/icl-jupyterhub-triton/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_TAG
 
-FROM pbchekin/icl-jupyterhub:0.0.22
+FROM pbchekin/icl-jupyterhub:0.0.23
 
 USER root
 

--- a/docker/icl-jupyterhub/Dockerfile
+++ b/docker/icl-jupyterhub/Dockerfile
@@ -11,6 +11,8 @@ RUN set -ex; \
     python -m build
 
 RUN set -ex; \
+    # python:3.12 images do not include setuptools and wheel, required for "setup.py bdist_wheel"
+    pip install setuptools wheel; \
     git clone https://github.com/dirkcgrunwald/jupyter_codeserver_proxy-.git; \
     cd jupyter_codeserver_proxy-; \
     make build-package

--- a/docker/icl-jupyterhub/entrypoint.sh
+++ b/docker/icl-jupyterhub/entrypoint.sh
@@ -16,6 +16,18 @@ cd ~
 if [[ ! -d $conda_prefix ]]; then
   echo "$conda_prefix does not exists, copying from /template"
   tar x -Ipixz -f /template/conda.tar.xz
+elif [[ ! -d $conda_prefix/envs/$kernel_env ]]; then
+  # The existing conda prefix was created by an older image and does not have
+  # the expected kernel environment: back it up and copy a new one from /template.
+  conda_backup=$HOME/.conda.bak.$(date +%Y%m%d%H%M%S)
+  echo "$conda_prefix does not have environment $kernel_env, moving it to $conda_backup and copying from /template"
+  mv $conda_prefix $conda_backup
+  tar x -Ipixz -f /template/conda.tar.xz
+  # .profile may activate an environment that only exists in the old prefix
+  if [[ -f ~/.profile ]]; then
+    sed -i "s/^conda activate python-3\..*/conda activate $kernel_env/" ~/.profile
+  fi
+  unset conda_backup
 fi
 
 if [[ ! -f ~/.profile ]]; then
@@ -39,13 +51,15 @@ if [[ ! -f ~/.jupyter/jupyter_config.json ]]; then
   }
 }
 EOF
+fi
 
-  # Use environment name for display_name
-  kernel_json=$conda_prefix/envs/$kernel_env/share/jupyter/kernels/python3/kernel.json
+# Use environment name for display_name
+kernel_json=$conda_prefix/envs/$kernel_env/share/jupyter/kernels/python3/kernel.json
+if [[ -f $kernel_json ]]; then
   jq ".display_name = \"$kernel_env\"" $kernel_json > /tmp/kernel.json
   mv /tmp/kernel.json $kernel_json
-  unset kernel_json
 fi
+unset kernel_json
 
 source $conda_prefix/etc/profile.d/conda.sh
 conda activate $jupyterlab_env

--- a/docker/icl-jupyterhub/readme.md
+++ b/docker/icl-jupyterhub/readme.md
@@ -3,21 +3,15 @@ Overview
 conda-based
 passwordless sudo, potentially can be disabled later
 additional packages installed (gh cli, ssh, vim, rsync, s3cmd)
-Modin, Prefect, Ray, ICL
+ICL (infractl) with Prefect 3.x in the python-3.12 kernel environment, built from the repository sources
 Build and push the image
-TARGET_TAG=pbchekin/icl-jupyterhub:latest
-MODIN_VERSION="0.26.1"
-PREFECT_VERSION="2.13.0"
-RAY_VERSION="2.9.2"
+TARGET_TAG=pbchekin/icl-jupyterhub:0.0.23
 Needs to be run from the root of the repository:
 
 docker build . \
     --file docker/icl-jupyterhub/Dockerfile \
     --progress=plain \
-    --tag $TARGET_TAG \
-    --build-arg PREFECT_VERSION="$PREFECT_VERSION" \
-    --build-arg MODIN_VERSION="$MODIN_VERSION" \
-    --build-arg RAY_VERSION="$RAY_VERSION"    
+    --tag $TARGET_TAG
 docker push $TARGET_TAG
 Create custom JupyterLab kernel
 In Terminal, create a new conda environment and install ipykernel.

--- a/scripts/deploy/kind.sh
+++ b/scripts/deploy/kind.sh
@@ -448,6 +448,12 @@ if [[ " $@ " =~ " --with-cert-manager " ]]; then
   terraform_extra_args+=( -var cert_manager_enabled=true )
 fi
 
+# Use a custom JupyterHub single-user image, for example a locally built one
+# loaded into the kind cluster with "kind load docker-image <image> --name x1".
+if [[ -n "${ICL_JUPYTERHUB_IMAGE:-}" ]]; then
+  terraform_extra_args+=( -var jupyterhub_singleuser_default_image="$ICL_JUPYTERHUB_IMAGE" )
+fi
+
 with_corefile
 control_node "terraform -chdir=terraform/icl init -upgrade -input=false && terraform -chdir=terraform/icl apply -input=false -auto-approve ${terraform_extra_args[*]}"
 

--- a/scripts/etc/kind/images.txt
+++ b/scripts/etc/kind/images.txt
@@ -15,7 +15,7 @@ kuberay/operator:v0.4.0
 kubernetesui/dashboard:v2.6.0
 minio/console:v0.20.3
 minio/operator:v4.5.1
-pbchekin/icl-jupyterhub:0.0.18
+pbchekin/icl-jupyterhub:0.0.23
 pbchekin/icl-prefect:3.6.17-py3.12-icl0.0.4
 pbchekin/icl-ray:2.9.2-py312
 prefecthq/prefect:3.6.17-python3.12

--- a/terraform/icl/variables.tf
+++ b/terraform/icl/variables.tf
@@ -217,7 +217,7 @@ variable "jupyterhub_singleuser_volume_size" {
 variable "jupyterhub_singleuser_default_image" {
   description = "Default Docker image for JupyterHub default profile"
   # original image: jupyterhub/k8s-singleuser-sample:2.0.1-0.dev.git.6035.h643c0f0c
-  default = "pbchekin/icl-jupyterhub:0.0.22"
+  default = "pbchekin/icl-jupyterhub:0.0.23"
   type = string
 }
 


### PR DESCRIPTION
## What

Bumps the JupyterHub single-user image to `pbchekin/icl-jupyterhub:0.0.23` and fixes everything needed to actually build and roll it out:

- **Tag bump to 0.0.23** in `terraform/icl/variables.tf` (`jupyterhub_singleuser_default_image`), the `docker-icl-jupyterhub` workflow default, the Triton image base (`FROM`), and `scripts/etc/kind/images.txt` (which still listed 0.0.18).
- **Dockerfile build fix**: official `python:3.12` images no longer bundle `setuptools`/`wheel`, so the `jupyter_codeserver_proxy` step (`setup.py bdist_wheel`) failed with `ModuleNotFoundError: No module named 'setuptools'`. Now installed explicitly in the builder stage.
- **entrypoint.sh upgrade handling**: user home directories are persistent volumes, so existing users kept the old `python-3.9` conda env (with a Prefect 2.13-era infractl) forever — the entrypoint only extracted the conda template on first boot. Now, if the expected `python-3.12` kernel env is missing, the old prefix is backed up to `~/.conda.bak.<timestamp>` (not deleted), the new template is extracted, and `.profile` is repointed. The kernel display-name fix is also idempotent now instead of first-boot-only.
- **`ICL_JUPYTERHUB_IMAGE` override in `kind.sh`** so a locally built image (e.g. loaded with `kind load docker-image`) can be deployed without pushing to Docker Hub.
- **readme.md**: dropped `PREFECT_VERSION`/`MODIN_VERSION`/`RAY_VERSION` build args that the Dockerfile no longer accepts.

## Why

The published `0.0.22` image dates from October 2024 and predates the Prefect 3.6 migration: its kernel ships infractl with Prefect 2.13, which cannot talk to the Prefect **3.6.17** server that `terraform/icl` now deploys. Users following the README example hit `griffe`/circular-import errors from the stale client, and even redeploying with a new image would not have fixed existing sessions because of the persistent-home issue above.

## Notes for reviewers

- `0.0.23` does not exist on Docker Hub yet — the image needs to be built and pushed (workflow `docker-icl-jupyterhub.yaml`) before/alongside merging, or deployed locally via the new `ICL_JUPYTERHUB_IMAGE` override.
- The fixed build step was verified in a clean `python:3.12-bookworm` container; the infractl wheel baked into the image was verified to require `prefect>=3.6,<4`.
- The GPU profile images (`icl-jupyterhub-gpu:0.0.21`, Intel/NVIDIA variants) are still on old tags and need the same treatment separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)